### PR TITLE
Sdk v5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: https://github.com/econchick/interrogate
-    rev: 1.4.0
+    rev: 1.7.0
     hooks:
       - id: interrogate
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
+    rev: 7.1.1
     hooks:
       - id: flake8 # E***, W***, F***
         additional_dependencies:
@@ -19,7 +19,7 @@ repos:
           - pep8-naming # N8**
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
         # args: ["--profile", "black", "--filter-files"]
@@ -32,12 +32,12 @@ repos:
         args: [--in-place, --blank]
 
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 24.8.0
     hooks:
       - id: black
         args: [--line-length=79]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.11.1
     hooks:
       - id: mypy

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.11174536.svg)](https://doi.org/10.5281/zenodo.11174536)
 ## Requirements and installation
 
-Requires DLL driver files from Waters, packaged as `masslynx`: https://github.com/cooper-group-uol-robotics/masslynx_sdk (DOI: 10.5281/zenodo.11174323).
+Requires the official Python [MassLynxSDK](https://microapps.on-demand.waters.com/home/downloads/masslynx-sdk) from Waters. On runtime, a valid license will also be needed (`license.key` file).

--- a/README.md
+++ b/README.md
@@ -2,4 +2,24 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.11174536.svg)](https://doi.org/10.5281/zenodo.11174536)
 ## Requirements and installation
 
-Requires the official Python [MassLynxSDK](https://microapps.on-demand.waters.com/home/downloads/masslynx-sdk) from Waters. On runtime, a valid license will also be needed (`license.key` file).
+Requires the official Python SDK from Waters. On runtime, a valid license will also be needed.
+
+### MassLynxSDK
+
+The [MassLynxSDK](https://microapps.on-demand.waters.com/home/downloads/masslynx-sdk) needs to be requested from Waters directly and the EULA will need to be accepted. It can be installed within the desired environment directly from the wheel file provided with the package - it can be found in one of the zipped directories:
+
+```
+pip install masslynxsdk-5.0.0-py3-none-any.whl
+```
+
+## MassLynxSDK license
+
+The license key (string found in the `license.key` file) needs to be provided when interfacing with the API:
+
+```python
+from lcms_parser import WatersRawFile
+
+raw_file = WatersRawFile(path="test.raw", license_key="XXXXXX")
+```
+
+Alternatively, the `license_key` parameter can be omitted as long as a valid `license.key` file is present in the current working directory.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Parser for UPLC-MS raw data in A.I.C. Group
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.11174536.svg)](https://doi.org/10.5281/zenodo.11174536)
+
 ## Requirements and installation
 
 Requires the official Python SDK from Waters. On runtime, a valid license will also be needed.
@@ -12,7 +13,7 @@ The [MassLynxSDK](https://microapps.on-demand.waters.com/home/downloads/masslynx
 pip install masslynxsdk-5.0.0-py3-none-any.whl
 ```
 
-## MassLynxSDK license
+### MassLynxSDK license
 
 The license key (string found in the `license.key` file) needs to be provided when interfacing with the API:
 
@@ -23,3 +24,12 @@ raw_file = WatersRawFile(path="test.raw", license_key="XXXXXX")
 ```
 
 Alternatively, the `license_key` parameter can be omitted as long as a valid `license.key` file is present in the current working directory.
+
+## Notes to developers and contributors
+
+There are linters and formatters in use for this project. Prior to contributing code, please make sure that your development environment is set up. Typically, an editable version would be installed for development and `pre-commit` would ensure that the code conforms to the standards before it is commmitted to GitHub:
+
+```
+pip install -e .[dev]
+pre-commit install
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,19 +7,19 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "lcms_parser"
 description = "Parser for the LCMS raw instrument files."
-version = "0.3.5"
-requires-python = ">=3.11"
+version = "2.0.0"
+requires-python = ">=3.12"
 authors = [
     { name = "Sriram Vijayakrishnan", email = "Sriram.Vijayakrishnan@liverpool.ac.uk" },
     { name = "Filip T. Szczypiński", email = "fiszczyp@gmail.com" },
 ]
 dependencies = [
-    "masslynx",
+    "masslynxsdk",
     "scipy",
     "numpy",
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Programming Language :: Python :: 3",
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Chemistry",
@@ -31,6 +31,7 @@ classifiers = [
         "black",
         "docformatter",
         "interrogate",
+        "ipython",
         "isort",
         "pycodestyle",
         "pydocstyle",
@@ -61,7 +62,8 @@ ignore-magic = true
 [[tool.mypy.overrides]]
 module = [
     'scipy.signal',
-    'masslynx',
+    'scipy.integrate',
+    'masslynxsdk',
 ]
 ignore_missing_imports = true
 

--- a/src/lcms_parser/__init__.py
+++ b/src/lcms_parser/__init__.py
@@ -22,7 +22,7 @@ from lcms_parser.traces.ion import (
     TICTracePeak,
 )
 
-__version__ = "0.3.5"
+__version__ = "2.0.0"
 __all__ = (
     "ExpectedResults",
     "HitIdentifier",

--- a/src/lcms_parser/experimental/hits.py
+++ b/src/lcms_parser/experimental/hits.py
@@ -45,8 +45,6 @@ class HitIdentifier(Experimental):
     ) -> list[MassSpectrumExperimentalHit]:
         """Identify hits in the .RAW file.
 
-
-
         Parameters
         ----------
         expected_results
@@ -69,6 +67,7 @@ class HitIdentifier(Experimental):
         Returns
         -------
             A list of experimental hits identified in the MS.
+
         """
 
         if time is None:

--- a/src/lcms_parser/experimental/planner.py
+++ b/src/lcms_parser/experimental/planner.py
@@ -1,6 +1,5 @@
 """Module to deal with planning what is expected."""
 
-
 from collections import UserDict
 
 import numpy as np


### PR DESCRIPTION
Switching to the official Waters MassLynxSDK. The main difference is that the API now requires a license_key for all operations that involve reading .RAW files. This can be supplied either as a string when initalising the WatersRawFile class or present in the working directory as supplied by Waters.