### PR TITLE
Allow for unscaled data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ build/
 .coverage
 
 tests/
+venv/
+wheels/

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Alternatively, the `license_key` parameter can be omitted as long as a valid `li
 There are linters and formatters in use for this project. Prior to contributing code, please make sure that your development environment is set up. Typically, an editable version would be installed for development and `pre-commit` would ensure that the code conforms to the standards before it is commmitted to GitHub:
 
 ```
-pip install -e .[dev]
+python -m venv venv
+venv\Scripts\activate
+pip install -e .[dev] --find-links wheels
 pre-commit install
 ```
+
+Ensure that the [`masslynxsdk`](https://microapps.on-demand.waters.com/home/downloads/masslynx-sdk) from Waters is either installed on the system or that the wheel is present in `wheels/`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,8 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "lcms_parser"
 description = "Parser for the LCMS raw instrument files."
-version = "2.0.0"
-requires-python = ">=3.12"
+version = "2.1.0"
+requires-python = ">=3.10"
 authors = [
     { name = "Sriram Vijayakrishnan", email = "Sriram.Vijayakrishnan@liverpool.ac.uk" },
     { name = "Filip T. Szczypiński", email = "fiszczyp@gmail.com" },

--- a/src/lcms_parser/__init__.py
+++ b/src/lcms_parser/__init__.py
@@ -22,7 +22,7 @@ from lcms_parser.traces.ion import (
     TICTracePeak,
 )
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"
 __all__ = (
     "ExpectedResults",
     "HitIdentifier",

--- a/src/lcms_parser/fileio/waters.py
+++ b/src/lcms_parser/fileio/waters.py
@@ -125,6 +125,7 @@ class WatersRawFile(HitIdentifier):
     def get_analog_trace(
         self,
         channel_id: int = 0,
+        scale: bool = True,
     ) -> AnalogTrace:
         """Get AnalogTrace from the LC data file.
 
@@ -136,6 +137,9 @@ class WatersRawFile(HitIdentifier):
         ----------
         channel_id, optional
             Analog channel to be extracted, by default 0
+
+        scale, optional
+            Scale the absorbance values to 1 A.U., by default True
 
         Returns
         -------
@@ -152,6 +156,7 @@ class WatersRawFile(HitIdentifier):
                 times=np.array(times),
                 intensities=np.array(intensities),
                 description=description.strip(),
+                scale=scale,
             )
             self.analog_traces[channel_id] = data
 


### PR DESCRIPTION
Now the codes allows to use raw analog LC integrals so that real peak integrals can be used for quantification.